### PR TITLE
Preserve header casing

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -81,7 +81,7 @@ function doRequest(method, url, options, callback) {
     // handle json body
     if (options.json) {
       options.body = JSON.stringify(options.json);
-      options.headers['content-type'] = 'application/json';
+      options.headers['Content-Type'] = 'application/json';
     }
 
     if (options.timeout) {
@@ -114,7 +114,7 @@ function doRequest(method, url, options, callback) {
     xhr.open(method, url, true);
 
     for (var name in options.headers) {
-      xhr.setRequestHeader(name.toLowerCase(), options.headers[name]);
+      xhr.setRequestHeader(name, options.headers[name]);
     }
 
     // avoid sending empty string (#319)

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "keywords": [],
   "browser": "./browser.js",
   "dependencies": {
-    "promise": "^6.0.1",
+    "caseless": "~0.9.0",
     "concat-stream": "^1.4.7",
-    "qs": "^2.3.3",
+    "http-basic": "^2.0.0",
     "http-response-object": "^1.0.1",
-    "http-basic": "^2.0.0"
+    "promise": "^6.0.1",
+    "qs": "^2.3.3"
   },
   "devDependencies": {
     "browserify": "^8.1.1",

--- a/test/browser.js
+++ b/test/browser.js
@@ -17,7 +17,6 @@ XMLHttpRequest.prototype.open = function (method, url, async) {
   this._url = url;
 };
 XMLHttpRequest.prototype.setRequestHeader = function (name, value) {
-  assert(name === name.toLowerCase(), 'All headers must be lower case');
   this._headers[name] = value;
 };
 XMLHttpRequest.prototype.send = function (body) {

--- a/test/get-mock-response.js
+++ b/test/get-mock-response.js
@@ -13,7 +13,7 @@ function getResponse(method, url, headers, body, options) {
     return new Response(200, {FoO: 'baz'}, 'body');
   }
   if (method === 'POST' && url === 'http://example.com') {
-    assert(headers['content-type'] === 'application/json');
+    assert(headers['Content-Type'] === 'application/json');
     assert(JSON.parse(body.toString()).foo === 'baz');
     return new Response(200, {}, 'json body');
   }


### PR DESCRIPTION
* Use [`caseless`](https://github.com/request/caseless) to manage header casing

Unfortunately there are apps out there that require specific header cases. For example phantomjs. The current implementation of forcing all headers to be lower-case makes phantomjs ignore or at least misinterpret the body.

See: https://github.com/groupon-testium/webdriver-http-sync/issues/25

*Edit: Sorry, thought I tried running the tests locally and they passed. Fixing now.*